### PR TITLE
Fix paths on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ Uploader.prototype.addDirectory = function(dir) {
 };
 
 Uploader.prototype.upload = function(file, buffer, root) {
-  var key = file.split(root + '/').pop();
+  var key = file.split(root + path.sep).pop();
 
   if (this.failed) {
     return;


### PR DESCRIPTION
Make sure you don't get super long paths on windows by using a platform independent directory separator